### PR TITLE
Allow custom preset sorting

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,8 @@ Complete configuration showing all available options:
     "defaultUseSegments": false,
     "defaultUsePresetService": true,
     "defaultUseWebSockets": true,
-    "defaultPollInterval": 10
+    "defaultPollInterval": 10,
+    "defaultPresetSorting": "id"
   },
   "manualDevicesSection": {
     "devices": [
@@ -113,7 +114,8 @@ Complete configuration showing all available options:
           "usePresetService": true,
           "useWebSockets": true,
           "pollInterval": 10,
-          "enabledPresets": ["1", "2", "3"]
+          "enabledPresets": ["1", "2", "3"],
+          "presetSorting": "name"
         }
       },
       {
@@ -150,6 +152,7 @@ Settings in `defaultSettingsSection` apply to devices added through the Discover
 | `defaultUsePresetService` | boolean | Add preset controls for discovered devices | `true` | No |
 | `defaultUseWebSockets` | boolean | Use WebSockets for discovered devices | `true` | No |
 | `defaultPollInterval` | integer | Polling interval for discovered devices (seconds) | `10` | No |
+| `defaultPresetSorting` | string | Default method for sorting presets in HomeKit ("id" or "name"); no effect if `enabledPresets` is set (that order will be used) | `"id"` | No |
 
 ### Manual Device Configuration
 
@@ -173,6 +176,7 @@ Settings in `deviceSettings` object control individual device behavior:
 | `useWebSockets` | boolean | Use WebSockets for real-time updates (requires WLED v0.13+) | `true` | No |
 | `pollInterval` | integer | How often to poll for state updates (seconds) | `10` | No |
 | `enabledPresets` | array | Array of preset IDs to expose (e.g., `["1", "2", "3"]`). Configure via UI. | `[]` | No |
+| `presetSorting` | string | Method for sorting presets in HomeKit ("id" or "name"); no effect if `enabledPresets` is set (that order will be used) | `"id"` | No |
 
 ## Feature Details
 

--- a/config.schema.json
+++ b/config.schema.json
@@ -54,6 +54,16 @@
             "description": "Use WebSockets for real-time updates on automatically discovered devices (requires WLED v0.13+)",
             "type": "boolean",
             "default": true
+          },
+          "defaultPresetSorting": {
+            "title": "Preset Sorting Method",
+            "description": "Default method for sorting presets in HomeKit. 'id' sorts by preset ID, 'name' sorts alphabetically by preset name. No effect if `enabledPresets` is set.",
+            "type": "string",
+            "default": "id",
+            "oneOf": [
+              { "title": "Sort by ID", "enum": ["id"] },
+              { "title": "Sort by Name", "enum": ["name"] }
+            ]
           }
         }
       },
@@ -120,6 +130,16 @@
                         "type": "string"
                       },
                       "default": []
+                    },
+                    "presetSorting": {
+                      "title": "Preset Sorting Method",
+                      "description": "Method for sorting presets in HomeKit. 'id' sorts by preset ID, 'name' sorts alphabetically by preset name. No effect if `enabledPresets` is set.",
+                      "type": "string",
+                      "default": "id",
+                      "oneOf": [
+                        { "title": "Sort by ID", "enum": ["id"] },
+                        { "title": "Sort by Name", "enum": ["name"] }
+                      ]
                     }
                   }
                 }

--- a/src/presetsAccessory.ts
+++ b/src/presetsAccessory.ts
@@ -108,7 +108,24 @@ export class WLEDPresetsAccessory {
     this.platform.log.info(`[DEBUG] Enabled presets for ${this.accessory.displayName}: ${JSON.stringify(enabledPresets)}`);
     this.platform.log.info(`[DEBUG] Filter by enabled: ${filterByEnabled}`);
 
-    for (const [presetIdStr, preset] of Object.entries(presets)) {
+    const sortedPresets = Object.entries(presets).filter(([presetIdStr]) => {
+      if (filterByEnabled && !enabledPresets.includes(presetIdStr)) {
+        this.platform.log.debug(`Skipping preset ${presetIdStr} - not in enabled presets list`);
+        return false;
+      }
+      return true;
+    });
+
+    const sortingMethod = this.getSortingMethod(
+      this.accessory.context.device?.deviceSettings?.presetSorting ??
+        this.platform.config.defaultSettingsSection?.defaultPresetSorting ??
+        'id',
+      enabledPresets
+    );
+
+    sortedPresets.sort(sortingMethod);
+
+    for (const [presetIdStr, preset] of sortedPresets) {
       this.platform.log.info(`[DEBUG] Processing preset - presetIdStr: "${presetIdStr}"`);
 
       const presetId = parseInt(presetIdStr, 10);
@@ -119,22 +136,15 @@ export class WLEDPresetsAccessory {
         continue;
       }
 
-      if (filterByEnabled && !enabledPresets.includes(presetIdStr)) {
-        this.platform.log.debug(`Skipping preset ${presetId} - not in enabled presets list`);
-        continue;
-      }
-
       this.platform.log.info(`[DEBUG] Preset data.n: "${preset.data?.n}", data.ql: "${preset.data?.ql}"`);
 
       this.presetInputMap.set(presetId, presetId);
       this.inputPresetMap.set(presetId, presetId);
 
       const serviceName = `Preset ${presetId}`;
-      const n = preset.data?.n || `Preset ${presetId}`;
-      const ql = preset.data?.ql || '';
-      const label = (ql ? `${ql} ` : '') + `${n}`;
+      const label = this.getPresetLabel(presetIdStr, preset.data);
 
-      this.platform.log.info(`[DEBUG] Creating preset - ID: ${presetId}, serviceName: "${serviceName}", label: "${label}" (ql: "${ql}", n: "${n}"`);
+      this.platform.log.info(`[DEBUG] Creating preset - ID: ${presetId}, serviceName: "${serviceName}", label: "${label}"`);
 
       const inputService = this.accessory.getService(serviceName) ||
         this.accessory.addService(this.platform.Service.InputSource, label, label);
@@ -208,5 +218,37 @@ export class WLEDPresetsAccessory {
 
   async setRemoteKey(_value: CharacteristicValue): Promise<void> {
     // No-op: remote key presses are not handled
+  }
+
+  private getSortingMethod(method: 'id' | 'name', explicitOrder?: string[]): (a: [string, any], b: [string, any]) => number {
+    if (explicitOrder && explicitOrder.length > 0) {
+      this.platform.log.info(`[DEBUG] Sorting presets by explicit order: ${JSON.stringify(explicitOrder)}`);
+      const orderMap = new Map<string, number>();
+      explicitOrder.forEach((id, index) => orderMap.set(id, index));
+      return (a, b) => {
+        const aIndex = orderMap.has(a[0]) ? orderMap.get(a[0])! : Number.POSITIVE_INFINITY;
+        const bIndex = orderMap.has(b[0]) ? orderMap.get(b[0])! : Number.POSITIVE_INFINITY;
+        return aIndex - bIndex;
+      };
+    }
+    if (method === 'id') {
+      this.platform.log.info('[DEBUG] Sorting presets by ID');
+      return (a, b) => parseInt(a[0], 10) - parseInt(b[0], 10);
+    }
+    if (method === 'name') {
+      this.platform.log.info('[DEBUG] Sorting presets by name');
+      return (a, b) => this.getPresetLabel(...a).localeCompare(this.getPresetLabel(...b));
+    }
+    throw new Error(`Invalid sorting method: ${method}`);
+  }
+
+  private getPresetLabel(presetId: string, preset: {data: {n?: string; ql?: string}}): string {
+    const n = preset.data?.n || `Preset ${presetId}`;
+    const ql = preset.data?.ql || '';
+    const label = (ql ? `${ql} ` : '') + `${n}`;
+
+    this.platform.log.info(`[DEBUG] Generated label "${label}" for preset ID ${presetId}`);
+
+    return label;
   }
 }

--- a/src/wledDevice.ts
+++ b/src/wledDevice.ts
@@ -927,7 +927,7 @@ export class WLEDDevice {
       this.presets = {};
 
       for (const [id, data] of Object.entries(rawPresets)) {
-        if (typeof data === 'object' && data !== null) {
+        if (typeof data === 'object' && data !== null && Object.keys(data).length !== 0) {
           // Extract name (n) and quick label (ql) for the preset
           const n = ('n' in data && typeof data.n === 'string') ? data.n : `Preset ${id}`;
           const ql = ('ql' in data && typeof data.ql === 'string') ? data.ql : '';


### PR DESCRIPTION
This adds an option to sort presets by ID or name (or the specified order from `enabledPresets`). This prevents the preset list in the TV accessory from being sorted in an undefined order and should allow whatever user customization is desired.

Thanks for the great plugin!