### PR TITLE
Make light and TV services optional

### DIFF
--- a/DISCOVERY_GUIDE.md
+++ b/DISCOVERY_GUIDE.md
@@ -39,7 +39,6 @@ If auto-discovery doesn't find your devices, you can add them manually:
         "port": 80,
         "deviceSettings": {
           "useSegments": false,
-          "usePresetService": true,
           "useWebSockets": true,
           "pollInterval": 10
         }

--- a/README.md
+++ b/README.md
@@ -97,7 +97,8 @@ Complete configuration showing all available options:
   "defaultPollInterval": 10,
   "defaultSettingsSection": {
     "defaultUseSegments": false,
-    "defaultUsePresetService": true,
+    "defaultEnablePresetService": true,
+    "defaultEnableLightService": true,
     "defaultUseWebSockets": true,
     "defaultPollInterval": 10
   },
@@ -110,7 +111,8 @@ Complete configuration showing all available options:
         "enabled": true,
         "deviceSettings": {
           "useSegments": false,
-          "usePresetService": true,
+          "enablePresetService": true,
+          "enableLightService": true,
           "useWebSockets": true,
           "pollInterval": 10,
           "enabledPresets": ["1", "2", "3"]
@@ -121,7 +123,7 @@ Complete configuration showing all available options:
         "host": "wled-bedroom.local",
         "deviceSettings": {
           "useSegments": true,
-          "usePresetService": true
+          "enablePresetService": true
         }
       }
     ]
@@ -147,7 +149,8 @@ Settings in `defaultSettingsSection` apply to devices added through the Discover
 | Property | Type | Description | Default | Required |
 |----------|------|-------------|---------|----------|
 | `defaultUseSegments` | boolean | Expose LED segments for discovered devices | `false` | No |
-| `defaultUsePresetService` | boolean | Add preset controls for discovered devices | `true` | No |
+| `defaultEnablePresetService` | boolean | Add preset controls for discovered devices | `true` | No |
+| `defaultEnableLightService` | boolean | Add light controls for discovered devices | `true` | No |
 | `defaultUseWebSockets` | boolean | Use WebSockets for discovered devices | `true` | No |
 | `defaultPollInterval` | integer | Polling interval for discovered devices (seconds) | `10` | No |
 
@@ -169,7 +172,8 @@ Settings in `deviceSettings` object control individual device behavior:
 | Property | Type | Description | Default | Required |
 |----------|------|-------------|---------|----------|
 | `useSegments` | boolean | Expose each LED segment as a separate accessory | `false` | No |
-| `usePresetService` | boolean | Add preset selector controls | `true` | No |
+| `enablePresetService` | boolean | Add preset selector controls | `true` | No |
+| `enableLightService` | boolean | Add light controls (power, brightness, color) | `true` | No |
 | `useWebSockets` | boolean | Use WebSockets for real-time updates (requires WLED v0.13+) | `true` | No |
 | `pollInterval` | integer | How often to poll for state updates (seconds) | `10` | No |
 | `enabledPresets` | array | Array of preset IDs to expose (e.g., `["1", "2", "3"]`). Configure via UI. | `[]` | No |
@@ -212,7 +216,7 @@ By default, this plugin creates preset controls for each WLED device, allowing y
 ```json
 {
   "deviceSettings": {
-    "usePresetService": true
+    "enablePresetService": true
   }
 }
 ```
@@ -221,7 +225,7 @@ By default, this plugin creates preset controls for each WLED device, allowing y
 ```json
 {
   "deviceSettings": {
-    "usePresetService": true,
+    "enablePresetService": true,
     "enabledPresets": ["1", "2", "5"]
   }
 }
@@ -230,13 +234,26 @@ By default, this plugin creates preset controls for each WLED device, allowing y
 **Tip:** Use the Discovery UI's preset manager to easily select which presets to enable!
 
 **Disabling Presets:**
-If you don't want preset controls, set `usePresetService` to `false`:
+If you don't want preset controls, set `enablePresetService` to `false`:
 ```json
 {
   "deviceSettings": {
-    "usePresetService": false
+    "enablePresetService": false
   }
 }
+```
+
+### Light controls
+By default, the plugin creates a light accessory for each WLED device that allows you to control power, brightness, and color like a standard lightbulb.
+
+If you don't want this, set `enableLightService` to `false` in the device settings:
+```json
+{
+  "deviceSettings": {
+    "enableLightService": false
+  }
+}
+```
 
 ### WebSocket Support
 
@@ -337,7 +354,7 @@ For devices that can't be discovered automatically, or if you prefer explicit co
 **Problem:** WLED presets don't show up or aren't updating in HomeKit
 
 **Solutions:**
-- Ensure `usePresetService` is set to `true` (it's enabled by default)
+- Ensure `enablePresetService` is set to `true` (it's enabled by default)
 - Create presets in your WLED device first (they must exist to be discovered)
 - If using `enabledPresets`, verify the preset IDs are correct (e.g., `["1", "2", "3"]`)
 - Restart Homebridge to refresh preset list

--- a/config-example.json
+++ b/config-example.json
@@ -15,7 +15,8 @@
       },
       "defaultSettingsSection": {
         "defaultUseSegments": false,
-        "defaultUsePresetService": true,
+        "defaultEnablePresetService": true,
+        "defaultEnableLightService": true,
         "defaultUseWebSockets": true,
         "defaultPollInterval": 10
       },
@@ -27,7 +28,8 @@
             "port": 80,
             "deviceSettings": {
               "useSegments": true,
-              "usePresetService": true,
+              "enablePresetService": true,
+              "enableLightService": true,
               "useWebSockets": true,
               "pollInterval": 5
             }

--- a/config.schema.json
+++ b/config.schema.json
@@ -43,9 +43,15 @@
         "title": "Default Settings for Auto-Discovered Devices",
         "type": "object",
         "properties": {
-          "defaultUsePresetService": {
+          "defaultEnablePresetService": {
             "title": "Add Preset Controls",
             "description": "Create preset control accessory for automatically discovered devices",
+            "type": "boolean",
+            "default": true
+          },
+          "defaultEnableLightService": {
+            "title": "Add Light Controls",
+            "description": "Create light (brightness/color) control accessory for automatically discovered devices",
             "type": "boolean",
             "default": true
           },
@@ -100,9 +106,15 @@
                   "type": "object",
                   "title": "Device Settings",
                   "properties": {
-                    "usePresetService": {
+                    "enablePresetService": {
                       "title": "Add Preset Controls",
                       "description": "Create preset control accessory for this device",
+                      "type": "boolean",
+                      "default": true
+                    },
+                    "enableLightService": {
+                      "title": "Add Light Controls",
+                      "description": "Create light (brightness/color) control accessory for this device",
                       "type": "boolean",
                       "default": true
                     },

--- a/homebridge-ui/public/index.html
+++ b/homebridge-ui/public/index.html
@@ -1070,7 +1070,8 @@
           ...(macAddress ? { macAddress } : {}),
           ...(ledCount ? { ledCount } : {}),
           deviceSettings: {
-            usePresetService: true,
+            enablePresetService: true,
+            enableLightService: true,
             useWebSockets: true,
           }
         };

--- a/homebridge-ui/server.ts
+++ b/homebridge-ui/server.ts
@@ -194,7 +194,8 @@ class PluginUiServer extends HomebridgePluginUiServer {
         host: accessory.context?.device?.host || 'Unknown',
         port: accessory.context?.device?.port || 80,
         uuid: accessory.UUID,
-        usePresetService: accessory.context?.device?.usePresetService !== false,
+        enablePresetService: accessory.context?.device?.enablePresetService !== false,
+        enableLightService: accessory.context?.device?.enableLightService !== false,
         useWebSockets: accessory.context?.device?.useWebSockets !== false,
       }));
 

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -123,12 +123,18 @@ export class WLEDPlatform implements DynamicPlatformPlugin {
 
       // Get settings from either nested or flat config structure
       const defaultSettings = this.config.defaultSettingsSection || {};
-      const defaultPollInterval = defaultSettings.defaultPollInterval !== undefined
-        ? defaultSettings.defaultPollInterval
-        : this.config.defaultPollInterval || 10;
-      const defaultUseWebSockets = defaultSettings.defaultUseWebSockets !== undefined
-        ? defaultSettings.defaultUseWebSockets
-        : this.config.defaultUseWebSockets !== false;
+      const defaultPollInterval =
+        defaultSettings.defaultPollInterval ?? this.config.defaultPollInterval ?? 10;
+      const defaultUseWebSockets =
+        defaultSettings.defaultUseWebSockets ?? this.config.defaultUseWebSockets ?? true;
+      const enablePresetService =
+        defaultSettings.defaultEnablePresetService ??
+        this.config.defaultEnablePresetService ??
+        true;
+      const enableLightService =
+        defaultSettings.defaultEnableLightService ??
+        defaultSettings.defaultEnableLightService ??
+        true;
 
       // Create the WLED device instance
       const wledDevice = new WLEDDevice(
@@ -146,13 +152,24 @@ export class WLEDPlatform implements DynamicPlatformPlugin {
       const deviceContext = { name: displayName, host: device.host, port: device.port };
 
       // --- Light accessory ---
-      const existingLightAccessory = this.accessories.find(a => a.UUID === lightUuid);
-      if (existingLightAccessory) {
-        this.log.info('Restoring existing light accessory from cache:', existingLightAccessory.displayName);
+      const existingLightAccessory = this.accessories.find((a) => a.UUID === lightUuid);
+      if (existingLightAccessory && !enableLightService) {
+        this.log.info(
+          'Unregistering existing light accessory (light service disabled):',
+          existingLightAccessory.displayName,
+        );
+        this.api.unregisterPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [
+          existingLightAccessory,
+        ]);
+      } else if (existingLightAccessory) {
+        this.log.info(
+          'Restoring existing light accessory from cache:',
+          existingLightAccessory.displayName,
+        );
         existingLightAccessory.context.device = deviceContext;
         new WLEDLightAccessory(this, existingLightAccessory, wledDevice);
         this.api.updatePlatformAccessories([existingLightAccessory]);
-      } else {
+      } else if (enableLightService) {
         this.log.info('Adding new light accessory:', displayName);
         const lightAccessory = new this.api.platformAccessory(displayName, lightUuid);
         lightAccessory.context.device = deviceContext;
@@ -162,13 +179,22 @@ export class WLEDPlatform implements DynamicPlatformPlugin {
 
       // --- Presets/TV accessory ---
       const tvDisplayName = displayName + ' Presets';
-      const existingTVAccessory = this.accessories.find(a => a.UUID === tvUuid);
-      if (existingTVAccessory) {
-        this.log.info('Restoring existing TV accessory from cache:', existingTVAccessory.displayName);
+      const existingTVAccessory = this.accessories.find((a) => a.UUID === tvUuid);
+      if (existingTVAccessory && !enablePresetService) {
+        this.log.info(
+          'Unregistering existing TV accessory (preset service disabled):',
+          existingTVAccessory.displayName,
+        );
+        this.api.unregisterPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [existingTVAccessory]);
+      } else if (existingTVAccessory) {
+        this.log.info(
+          'Restoring existing TV accessory from cache:',
+          existingTVAccessory.displayName,
+        );
         existingTVAccessory.context.device = deviceContext;
         new WLEDPresetsAccessory(this, existingTVAccessory, wledDevice);
         this.api.updatePlatformAccessories([existingTVAccessory]);
-      } else {
+      } else if (enablePresetService) {
         this.log.info('Adding new TV accessory:', tvDisplayName);
         const tvAccessory = new this.api.platformAccessory(tvDisplayName, tvUuid, this.api.hap.Categories.TELEVISION);
         tvAccessory.context.device = deviceContext;
@@ -248,9 +274,19 @@ export class WLEDPlatform implements DynamicPlatformPlugin {
 
       const deviceContext = { ...device, name: displayName };
 
+      const enableLightService =
+        (deviceSettings.enableLightService ??
+          this.config.defaultSettingSection?.defaultEnableLightService) !== false;
+      const enablePresetService =
+        (deviceSettings.enablePresetService ??
+          this.config.defaultSettingSection?.defaultEnablePresetService) !== false;
+
       // --- Light accessory ---
       const existingLightAccessory = this.accessories.find(a => a.UUID === lightUuid);
-      if (existingLightAccessory) {
+      if (existingLightAccessory && !enableLightService) {
+        this.log.info('Unregistering existing light accessory (light service disabled):', existingLightAccessory.displayName);
+        this.api.unregisterPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [existingLightAccessory]);
+      } else if (existingLightAccessory) {
         this.log.info('Restoring existing light accessory from cache:', existingLightAccessory.displayName);
         if (existingLightAccessory.displayName !== displayName) {
           this.log.info(`Updating display name from "${existingLightAccessory.displayName}" to "${displayName}"`);
@@ -259,7 +295,7 @@ export class WLEDPlatform implements DynamicPlatformPlugin {
         existingLightAccessory.context.device = deviceContext;
         new WLEDLightAccessory(this, existingLightAccessory, wledDevice);
         this.api.updatePlatformAccessories([existingLightAccessory]);
-      } else {
+      } else if (enableLightService) {
         this.log.info('Adding new light accessory:', displayName);
         const lightAccessory = new this.api.platformAccessory(displayName, lightUuid);
         lightAccessory.context.device = deviceContext;
@@ -276,7 +312,10 @@ export class WLEDPlatform implements DynamicPlatformPlugin {
       const newEnabledPresets = device.deviceSettings?.enabledPresets || [];
       const presetsChanged = JSON.stringify([...oldEnabledPresets].sort()) !== JSON.stringify([...newEnabledPresets].sort());
 
-      if (existingTVAccessory) {
+      if (existingTVAccessory && !enablePresetService) {
+        this.log.info('Unregistering existing TV accessory (preset service disabled):', existingTVAccessory.displayName);
+        this.api.unregisterPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [existingTVAccessory]);
+      } else if (existingTVAccessory) {
         if (presetsChanged) {
           this.log.info(`Enabled presets changed for ${displayName}. Re-registering TV accessory to force Home app refresh...`);
           this.log.debug(`Old presets: ${JSON.stringify(oldEnabledPresets)}`);
@@ -304,7 +343,7 @@ export class WLEDPlatform implements DynamicPlatformPlugin {
           new WLEDPresetsAccessory(this, existingTVAccessory, wledDevice);
           this.api.updatePlatformAccessories([existingTVAccessory]);
         }
-      } else {
+      } else if (enablePresetService) {
         this.log.info('Adding new TV accessory:', tvDisplayName);
         const tvAccessory = new this.api.platformAccessory(tvDisplayName, tvUuid, this.api.hap.Categories.TELEVISION);
         tvAccessory.context.device = deviceContext;


### PR DESCRIPTION
Allows dynamically controlling if the preset and light services appear, to better fit use cases where only some are desired. I renamed to `enablePresetService` to be a bit more semantic and since the original wasn't implemented anyways.

Closes #1 